### PR TITLE
Update . notation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const replacement = '--REDACTED--';
 
 module.exports = (whitelist = []) => {
   const terms = whitelist.join('|');
-  const paths = new RegExp(`^(${terms.replace(/\*/g, '.*')})$`, 'i');
+  const paths = new RegExp(`^(${terms.replace('.', '\\.').replace(/\*/g, '.*')})$`, 'i');
 
   return values => {
     const clone = JSON.parse(stringify(values));

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -37,6 +37,12 @@ describe('Anonymizer', () => {
       });
     });
 
+    it(`should default to an empty whitelist`, () => {
+      const anonymize = anonymizer();
+
+      expect(anonymize({ foo: 'foo' })).toEqual({ foo: '--REDACTED--' });
+    });
+    
     it('should not obfuscate recursively the keys of an object that are part of the whitelist', () => {
       const anonymize = anonymizer(whitelist);
 

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -71,6 +71,12 @@ describe('Anonymizer', () => {
       expect(anonymize({ foo: 'bar' })).toEqual({ foo: 'bar' });
     });
 
+    it('should not treat a `.` in the whitelist as a special character in the regexp', () => {
+      const anonymize = anonymizer(['foo.bar']);
+
+      expect(anonymize({ foo: { bar: 'biz' }, fooabar: 'foobiz' })).toEqual({ foo: { bar: 'biz' }, fooabar: '--REDACTED--' });
+    });
+
     it('should allow using `*` in the whitelist path', () => {
       const anonymize = anonymizer(['*.foo', '*.foobar']);
 


### PR DESCRIPTION
This PR updates:
- the `.` notation is now escaped on the regexp

It also adds a missing test to bring coverage to 100%. 

#### Why the `*` change?

**Note: This change has been removed from this PR, but we should discuss this since having the `*` matching everything is somewhat dangerous**

The current behavior for * in the regexp is `.*`, this effectively whitelists any character, including the `.` that is used to delimit paths.

This means that currently `*.foo` of `foo.*` would match:

```
*.foo

.foo
a.foo
a.b.foo
a.b.c.foo
...
```

```
foo.*

foo.
foo.a
foo.a.b
foo.a.b.c
...
```

If this is truly expected behavior, we should think about adding the `**` pattern to match multiple paths.