### PR TITLE
Add a blacklist with higher priority than whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,37 @@
 # anonymizer
-Object redaction with whitelist as main feature.
+Object redaction with whitelist and blacklist. Blacklist items have higher priority and will always supercede the whitelist.
 
 ## Arguments
-1. `whitelist` _(Object)_: The whitelist object.
+1. `whitelist` _(Array)_: The whitelist array.
+2. `blacklist` _(Array)_: The blacklist array.
 
 ### Example
 
 ```js
 const anonymizer = require('@uphold/anonymizer');
-const whitelist = ['foo.key', 'bar.*'];
-const anonymize = anonymizer(whitelist);
+const whitelist = ['foo.key', 'foo.depth.*', 'bar.*', 'toAnonymize.baz', 'toAnonymizeSuperString'];
+const blacklist = ['foo.depth.innerBlacklist', 'toAnonymize.*'];
+const anonymize = anonymizer({ blacklist, whitelist });
 
-anonymize({ foo: { key: 'public', another: 'bar' }, bar: { foo: 1, bar: 2 } });
+const data = {
+  foo: { key: 'public', another: 'bar', depth: { bar: 10, innerBlacklist: 11 } },
+  bar: { foo: 1, bar: 2 },
+  toAnonymize: { baz: 11, bar: 12 },
+  toAnonymizeSuperString: 'foo'
+};
 
-//=> { foo: { key: 'public', another: '--REDACTED--' }, bar: { foo: 1, bar: 2 } }
+anonymize(data);
+
+// {
+//   foo: {
+//     key: 'public',
+//     another: '--REDACTED--',
+//     depth: { bar: 10, innerBlacklist: '--REDACTED--' }
+//   },
+//   bar: { foo: 1, bar: 2 },
+//   toAnonymize: { baz: '--REDACTED--', bar: '--REDACTED--' },
+//   toAnonymizeSuperString: '--REDACTED--'
+// }
 ```
 
 ## Releasing a new version

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,11 @@ const replacement = '--REDACTED--';
  * Module exports.
  */
 
-module.exports = (whitelist = []) => {
-  const terms = whitelist.join('|');
-  const paths = new RegExp(`^(${terms.replace('.', '\\.').replace(/\*/g, '.*')})$`, 'i');
+module.exports = ({ blacklist = [], whitelist = [] } = {}) => {
+  const whitelistTerms = whitelist.join('|');
+  const whitelistPaths = new RegExp(`^(${whitelistTerms.replace('.', '\\.').replace(/\*/g, '.*')})$`, 'i');
+  const blacklistTerms = blacklist.join('|');
+  const blacklistPaths = new RegExp(`^(${blacklistTerms.replace('.', '\\.').replace(/\*/g, '.*')})$`, 'i');
 
   return values => {
     const obj = clone(values);
@@ -29,17 +31,18 @@ module.exports = (whitelist = []) => {
         return '[Circular ~]';
       }
 
+      const path = this.path.join('.');
       const isBuffer = this.node instanceof Buffer;
 
       if (!isBuffer && !this.isLeaf) {
         return;
       }
 
-      if (isBuffer && paths.test(this.path.join('.'))) {
+      if (isBuffer && (!blacklistPaths.test(path) && whitelistPaths.test(path))) {
         return this.update(this.node, true);
       }
 
-      if (!paths.test(this.path.join('.'))) {
+      if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
         this.update(replacement);
       }
     });

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -12,104 +12,192 @@ const anonymizer = require('src');
 
 describe('Anonymizer', () => {
   describe('anonymize', () => {
-    const whitelist = ['key1', 'key2', 'key3'];
-
-    whitelist.forEach(key => {
-      it(`should not obfuscate \`${key}\``, () => {
-        const anonymize = anonymizer(whitelist);
-
-        expect(anonymize({ [key]: 'foo' })).toEqual({ [key]: 'foo' });
-      });
-
-      it(`should not obfuscate \`${key}\` with different casing`, () => {
-        const anonymize = anonymizer(whitelist);
-
-        expect(anonymize({ [key.toUpperCase()]: 'foo' })).toEqual({ [key.toUpperCase()]: 'foo' });
-        expect(anonymize({ [key.toLowerCase()]: 'foo' })).toEqual({ [key.toLowerCase()]: 'foo' });
-      });
-
-      it(`should obfuscate keys that contain \`${key}\``, () => {
-        const anonymize = anonymizer(whitelist);
-
-        expect(anonymize({ [`${key}foo`]: 'bar' })).toEqual({ [`${key}foo`]: '--REDACTED--' });
-        expect(anonymize({ [`foo${key}`]: 'bar' })).toEqual({ [`foo${key}`]: '--REDACTED--' });
-        expect(anonymize({ [`foo${key}foo`]: 'bar' })).toEqual({ [`foo${key}foo`]: '--REDACTED--' });
-      });
-    });
-
-    it(`should obfuscate keys whose type is Buffer`, () => {
-      const anonymize = anonymizer();
-
-      expect(anonymize({ foo: Buffer.from('foobarfoobar') })).toEqual({ foo: '--REDACTED--' });
-    });
-
-    it(`should not obfuscate Buffer-type keys that are whitelisted`, () => {
-      const anonymize = anonymizer(['foo']);
-
-      expect(anonymize({ foo: Buffer.from('foobarfoobar') })).toEqual({ foo: Buffer.from('foobarfoobar') });
-    });
-
-    it(`should default to an empty whitelist`, () => {
-      const anonymize = anonymizer();
-
-      expect(anonymize({ foo: 'foo' })).toEqual({ foo: '--REDACTED--' });
-    });
-
-    it('should not obfuscate recursively the keys of an object that are part of the whitelist', () => {
-      const anonymize = anonymizer(whitelist);
-
-      expect(
-        anonymize({
-          foo: {
-            bar: {
-              baz: { bax: [2, 3, { bax: 4, [whitelist[1]]: '5' }] },
-              [whitelist[0]]: 'foobar',
-              [whitelist[2]]: 'foobiz'
-            }
-          }
-        })
-      ).toEqual({
-        foo: {
-          bar: {
-            baz: { bax: ['--REDACTED--', '--REDACTED--', { bax: '--REDACTED--', [whitelist[1]]: '--REDACTED--' }] },
-            [whitelist[0]]: '--REDACTED--',
-            [whitelist[2]]: '--REDACTED--'
-          }
-        }
-      });
-    });
-
-    it('should not obfuscate a key that is part of the whitelist', () => {
-      const anonymize = anonymizer(['foo']);
-
-      expect(anonymize({ foo: 'bar' })).toEqual({ foo: 'bar' });
-    });
-
-    it('should not treat a `.` in the whitelist as a special character in the regexp', () => {
-      const anonymize = anonymizer(['foo.bar']);
-
-      expect(anonymize({ foo: { bar: 'biz' }, fooabar: 'foobiz' })).toEqual({
-        foo: { bar: 'biz' },
-        fooabar: '--REDACTED--'
-      });
-    });
-
-    it('should allow using `*` in the whitelist path', () => {
-      const anonymize = anonymizer(['*.foo', '*.foobar']);
-
-      expect(anonymize({ parent: { foo: 'bar', foobar: 'foobiz' } })).toEqual({
-        parent: { foo: 'bar', foobar: 'foobiz' }
-      });
-    });
-
     it('should allow circular references', () => {
       const object = {};
 
       object.reference = object;
 
-      const anonymize = anonymizer(['*']);
+      const anonymize = anonymizer({ whitelist: ['*'] });
 
       expect(anonymize(object)).toEqual({ reference: '[Circular ~]' });
+    });
+
+    describe('whitelist', () => {
+      const whitelist = ['key1', 'key2', 'key3'];
+
+      whitelist.forEach(key => {
+        it(`should not obfuscate \`${key}\``, () => {
+          const anonymize = anonymizer({ whitelist });
+
+          expect(anonymize({ [key]: 'foo' })).toEqual({ [key]: 'foo' });
+        });
+
+        it(`should not obfuscate \`${key}\` with different casing`, () => {
+          const anonymize = anonymizer({ whitelist });
+
+          expect(anonymize({ [key.toUpperCase()]: 'foo' })).toEqual({ [key.toUpperCase()]: 'foo' });
+          expect(anonymize({ [key.toLowerCase()]: 'foo' })).toEqual({ [key.toLowerCase()]: 'foo' });
+        });
+
+        it(`should obfuscate keys that contain \`${key}\``, () => {
+          const anonymize = anonymizer({ whitelist });
+
+          expect(anonymize({ [`${key}foo`]: 'bar' })).toEqual({ [`${key}foo`]: '--REDACTED--' });
+          expect(anonymize({ [`foo${key}`]: 'bar' })).toEqual({ [`foo${key}`]: '--REDACTED--' });
+          expect(anonymize({ [`foo${key}foo`]: 'bar' })).toEqual({ [`foo${key}foo`]: '--REDACTED--' });
+        });
+      });
+
+      it(`should obfuscate keys whose type is Buffer`, () => {
+        const anonymize = anonymizer();
+
+        expect(anonymize({ foo: Buffer.from('foobarfoobar') })).toEqual({ foo: '--REDACTED--' });
+      });
+
+      it(`should not obfuscate Buffer-type keys that are whitelisted`, () => {
+        const anonymize = anonymizer({ whitelist: ['foo'] });
+
+        expect(anonymize({ foo: Buffer.from('foobarfoobar') })).toEqual({ foo: Buffer.from('foobarfoobar') });
+      });
+
+      it(`should default to an empty whitelist`, () => {
+        const anonymize = anonymizer();
+
+        expect(anonymize({ foo: 'foo' })).toEqual({ foo: '--REDACTED--' });
+      });
+
+      it('should not obfuscate recursively the keys of an object that are part of the whitelist', () => {
+        const anonymize = anonymizer({ whitelist });
+
+        expect(
+          anonymize({
+            foo: {
+              bar: {
+                baz: { bax: [2, 3, { bax: 4, [whitelist[1]]: '5' }] },
+                [whitelist[0]]: 'foobar',
+                [whitelist[2]]: 'foobiz'
+              }
+            }
+          })
+        ).toEqual({
+          foo: {
+            bar: {
+              baz: { bax: ['--REDACTED--', '--REDACTED--', { bax: '--REDACTED--', [whitelist[1]]: '--REDACTED--' }] },
+              [whitelist[0]]: '--REDACTED--',
+              [whitelist[2]]: '--REDACTED--'
+            }
+          }
+        });
+      });
+
+      it('should not obfuscate a key that is part of the whitelist', () => {
+        const anonymize = anonymizer({ whitelist: ['foo'] });
+
+        expect(anonymize({ foo: 'bar' })).toEqual({ foo: 'bar' });
+      });
+
+      it('should not treat a `.` in the whitelist as a special character in the regexp', () => {
+        const anonymize = anonymizer({ whitelist: ['foo.bar'] });
+
+        expect(anonymize({ foo: { bar: 'biz' }, fooabar: 'foobiz' })).toEqual({
+          foo: { bar: 'biz' },
+          fooabar: '--REDACTED--'
+        });
+      });
+
+      it('should allow using `*` in the whitelist path', () => {
+        const anonymize = anonymizer({ whitelist: ['*.foo', '*.foobar'] });
+
+        expect(anonymize({ parent: { foo: 'bar', foobar: 'foobiz' } })).toEqual({
+          parent: { foo: 'bar', foobar: 'foobiz' }
+        });
+      });
+    });
+
+    describe('blacklist', () => {
+      it(`should default to an empty blacklist`, () => {
+        const anonymize = anonymizer({ whitelist: ['foo'] });
+
+        expect(anonymize({ foo: 'foo' })).toEqual({ foo: 'foo' });
+      });
+
+      it('should not treat a `.` in the blacklist as a special character in the regexp', () => {
+        const anonymize = anonymizer({ blacklist: ['foo.bar'], whitelist: ['fooabar'] });
+
+        expect(anonymize({ foo: { bar: 'biz' }, fooabar: 'foobiz' })).toEqual({
+          foo: { bar: '--REDACTED--' },
+          fooabar: 'foobiz'
+        });
+      });
+
+      describe('in case of collision', () => {
+        it('should prioritize blacklist over whitelist', () => {
+          const anonymize = anonymizer({ blacklist: ['key1.innerKey1'], whitelist: ['key1.innerKey1'] });
+
+          expect(
+            anonymize({
+              key1: { innerKey1: 'bar', innerKey2: 'foo' }
+            })
+          ).toEqual({
+            key1: { innerKey1: '--REDACTED--', innerKey2: '--REDACTED--' }
+          });
+        });
+
+        it(`should obfuscate key with different casing`, () => {
+          const anonymize = anonymizer({ blacklist: ['key1'], whitelist: ['KEy1'] });
+
+          expect(anonymize({ KEy1: 'foo' })).toEqual({ KEy1: '--REDACTED--' });
+        });
+
+        it('should allow using `*` in blacklist path', () => {
+          const whitelist = ['key1.*', 'key2.innerKey2'];
+          const blacklist = ['*innerKey2'];
+          const anonymize = anonymizer({ blacklist, whitelist });
+
+          expect(
+            anonymize({
+              key1: { innerKey1: 'bar', innerKey2: 'bam' },
+              key2: { innerKey1: 'bar', innerKey2: 'bam' }
+            })
+          ).toEqual({
+            key1: { innerKey1: 'bar', innerKey2: '--REDACTED--' },
+            key2: { innerKey1: '--REDACTED--', innerKey2: '--REDACTED--' }
+          });
+        });
+
+        it(`should obfuscate Buffer-type keys that are blacklisted`, () => {
+          const anonymize = anonymizer({ blacklist: ['foo'], whitelist: ['foo'] });
+
+          expect(anonymize({ foo: Buffer.from('foobarfoobar') })).toEqual({ foo: '--REDACTED--' });
+        });
+
+        it('should obfuscate recursively the keys of an object that are part of the blacklist', () => {
+          const anonymize = anonymizer({
+            blacklist: ['foo.bar.*'],
+            whitelist: ['foo.bar.key1', 'foo.bar.key2', 'foo.bar.baz.bax.*', '*key1']
+          });
+
+          expect(
+            anonymize({
+              foo: {
+                bar: {
+                  baz: { bax: [2, 3, { bax: 4, key1: '5' }] },
+                  key1: 'foobar',
+                  key2: 'foobiz'
+                }
+              }
+            })
+          ).toEqual({
+            foo: {
+              bar: {
+                baz: { bax: ['--REDACTED--', '--REDACTED--', { bax: '--REDACTED--', key1: '--REDACTED--' }] },
+                key1: '--REDACTED--',
+                key2: '--REDACTED--'
+              }
+            }
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
In cases where it is desirable to log objects with many keys, mostly
whitelisted but with a few exceptions nested deep in the object, the
whitelist can become large and repetitive. This is resolved by adding a
blacklist allowing wildcarding, allowing anonymization of single keys,
deeply nested.

For defensive purposes, the blacklist should be prioritized more highly
than the whitelist. The assumption here is that it is of great
importance to anonymize an item placed on the blacklist. This also
prevents the class of errors in which items with wildcards are added to
the whitelist after initial implementation, causing sensitive data to be
logged despite being present on the blacklist.

One side effect or gotcha is that keys that are a super string of blacklisted
items with wildcards will be redacted regardless of their presence on
the whitelist and not explicitly being thought of for blacklisting
(i.e. the motivation for adding `toAnonymize.*` is to recursively
redact values under the `toAnonymize` key rather than keys of the type
`toAnonymizeSuperString`).

Resolves issue #27 