### PR TITLE
Add replacement customizer function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Object redaction with whitelist and blacklist. Blacklist items have higher prior
 ## Arguments
 1. `whitelist` _(Array)_: The whitelist array.
 2. `blacklist` _(Array)_: The blacklist array.
+3. `options` _(Object)_: An object with optional options.
+
+    `options.replacement` _(Function)_: A function that allows customizing the replacement value (default implementation is `--REDACTED--`).
 
 ### Example
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,13 +11,13 @@ const traverse = require('traverse');
  * Constants.
  */
 
-const replacement = '--REDACTED--';
+const DEFAULT_REPLACEMENT = '--REDACTED--';
 
 /**
  * Module exports.
  */
 
-module.exports = ({ blacklist = [], whitelist = [] } = {}) => {
+module.exports = ({ blacklist = [], whitelist = [] } = {}, { replacement = () => DEFAULT_REPLACEMENT } = {}) => {
   const whitelistTerms = whitelist.join('|');
   const whitelistPaths = new RegExp(`^(${whitelistTerms.replace('.', '\\.').replace(/\*/g, '.*')})$`, 'i');
   const blacklistTerms = blacklist.join('|');
@@ -42,8 +42,10 @@ module.exports = ({ blacklist = [], whitelist = [] } = {}) => {
         return this.update(this.node, true);
       }
 
+      const replacedValue = replacement(this.key, this.node, this.path);
+
       if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
-        this.update(replacement);
+        this.update(replacedValue);
       }
     });
 

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -199,5 +199,30 @@ describe('Anonymizer', () => {
         });
       });
     });
+
+    describe('replacement', () => {
+      it('should return the default replacement', () => {
+        const anonymize = anonymizer();
+
+        expect(anonymize({ foo: 'bar' })).toEqual({ foo: '--REDACTED--' });
+      });
+
+      it('should accept a customizer function', () => {
+        const replacement = (key, value) => {
+          const url = new URL(value);
+
+          for (const [search] of url.searchParams) {
+            url.searchParams.set(search, '--REDACTED--');
+          }
+
+          return url.toString();
+        };
+        const anonymize = anonymizer({}, { replacement });
+
+        expect(anonymize({ foo: 'https://example.com/?secret=verysecret' })).toEqual({
+          foo: 'https://example.com/?secret=--REDACTED--'
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds an optional `replacementCustomizer` function that allows altering the replacement value. This is useful in cases where you might not want to redact the entire value, but only part of it (example: a URL).