### PR TITLE
Fix obfuscation of class getter methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "version": "uphold-scripts version"
   },
   "dependencies": {
-    "clone": "^2.1.2",
+    "lodash.get": "^4.4.2",
     "traverse": "^0.6.6"
   },
   "devDependencies": {

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -22,6 +22,25 @@ describe('Anonymizer', () => {
       expect(anonymize(object)).toEqual({ reference: '[Circular ~]' });
     });
 
+    it('should obfuscate class getters', () => {
+      class Foobar {
+        get bar() {
+          return 'biz';
+        }
+
+        toJSON() {
+          return {
+            bar: this.bar
+          };
+        }
+      }
+
+      const anonymize = anonymizer({ whitelist: ['foo.bar'] });
+      const foo = new Foobar();
+
+      expect(anonymize({ foo })).toEqual({ foo: { bar: 'biz' } });
+    });
+
     describe('whitelist', () => {
       const whitelist = ['key1', 'key2', 'key3'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -838,11 +838,6 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
-clone@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
-  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
-
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2605,6 +2600,11 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Fixes an issue introduced in #23 that broke the ability to redact getter methods, when returned by a  `toJSON()` (such as sequelize).

Also, reverting the use of the `clone` package back to the much faster JSON.parse/stringify clone implementation.