### PR TITLE
Improve handling of wildcard character

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,9 @@ const DEFAULT_REPLACEMENT = '--REDACTED--';
 
 module.exports = ({ blacklist = [], whitelist = [] } = {}, { replacement = () => DEFAULT_REPLACEMENT } = {}) => {
   const whitelistTerms = whitelist.join('|');
-  const whitelistPaths = new RegExp(`^(${whitelistTerms.replace('.', '\\.').replace(/\*/g, '.*')})$`, 'i');
+  const whitelistPaths = new RegExp(`^(${whitelistTerms.replace(/\./g, '\\.').replace(/\*/g, '.*')})$`, 'i');
   const blacklistTerms = blacklist.join('|');
-  const blacklistPaths = new RegExp(`^(${blacklistTerms.replace('.', '\\.').replace(/\*/g, '.*')})$`, 'i');
+  const blacklistPaths = new RegExp(`^(${blacklistTerms.replace(/\./g, '\\.').replace(/\*/g, '.*')})$`, 'i');
 
   return values => {
     const obj = JSON.parse(stringify(values));

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -125,10 +125,10 @@ describe('Anonymizer', () => {
       });
 
       it('should allow using `*` in the whitelist path', () => {
-        const anonymize = anonymizer({ whitelist: ['*.foo', '*.foobar'] });
+        const anonymize = anonymizer({ whitelist: ['*.foo', '*.foobar', 'parent.*.biz'] });
 
-        expect(anonymize({ parent: { foo: 'bar', foobar: 'foobiz' } })).toEqual({
-          parent: { foo: 'bar', foobar: 'foobiz' }
+        expect(anonymize({ parent: { foo: 'bar', foobar: 'foobiz', quux: { biz: 'baz', foobiz: 'bar' } } })).toEqual({
+          parent: { foo: 'bar', foobar: 'foobiz', quux: { biz: 'baz', foobiz: '--REDACTED--' } }
         });
       });
     });


### PR DESCRIPTION
## Issue Description

### What are you doing?
I'm using the following whitelist:

````
foo.*.bar
````

To obfuscate the following object:

```js
{
  foo: {
    biz: {
      bar: 'bar',
      foobar: 'foobar'
    }
  }
}
```

### What do you expect to happen?
I would expect anonymizer to return the following result:

```js
{
  foo: {
    biz: {
      bar: 'bar',
      foobar: '--REDACTED--'
    }
  }
}
```

### What is actually happening?

Anonymizer is returning the following result: 

```js
{
  foo: {
    biz: {
      bar: 'bar',
      foobar: 'foobar'
    }
  }
}
```
