### PR TITLE
Trim redacted keys

### DIFF
--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -250,5 +250,23 @@ describe('Anonymizer', () => {
         });
       });
     });
+
+    describe('trim', () => {
+      it('should trim obfuscated fields and add their paths to a `__redacted__` list', () => {
+        const anonymize = anonymizer({ whitelist: ['foo'] }, { trim: true });
+
+        expect(
+          anonymize({
+            biz: 'baz',
+            buz: { qux: 'quux' },
+            foo: 'bar'
+          })
+        ).toEqual({
+          __redacted__: ['biz', 'buz.qux'],
+          buz: {},
+          foo: 'bar'
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
So that we don't get high volumes of mostly redacted objects.

This adds a new list called `__redacted__` that shows all paths that have been redacted.

Includes the work done on https://github.com/uphold/anonymizer/pull/40, as otherwise, it would break when passing strings to anonymizer.