### PR TITLE
Apply anonymizer to objects only

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,10 @@ module.exports = ({ blacklist = [], whitelist = [] } = {}, { replacement = () =>
   const blacklistPaths = new RegExp(`^(${blacklistTerms.replace(/\./g, '\\.').replace(/\*/g, '.*')})$`, 'i');
 
   return values => {
+    if (!(values instanceof Object)) {
+      return values;
+    }
+
     const obj = JSON.parse(stringify(values));
 
     traverse(obj).forEach(function() {

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -12,6 +12,13 @@ const anonymizer = require('src');
 
 describe('Anonymizer', () => {
   describe('anonymize', () => {
+    it('should not traverse and obfuscate values that are not objects', () => {
+      const anonymize = anonymizer({ whitelist: ['foo'] });
+      const text = JSON.stringify({ foo: 'bar', qux: 'biz' });
+
+      expect(anonymize(text)).toEqual(text);
+    });
+
     it('should allow circular references', () => {
       const object = {};
 


### PR DESCRIPTION
We were traversing the `values` object trying to apply the obfuscation rules even when that value wasn't an object. For instance, when we use anonymizer to log messages and those messages are strings, we're trying to traverse those strings, which is not useful.

This is even worse if we try to add new functionality on anonymizer that assumes we're dealing with objects since it could break on values such as strings.

Therefore, this PR makes anonymizer quit early if `values` isn't an object. This saves some computation time and avoids possible issues in the future.

The added test still passes without the corresponding code changes. That is because there is no behaviour change and no easy dependency to mock. You can check it's testing the correct code branches because they show as covered in the test coverage report, while if you delete the test they show as uncovered. This is not ideal but it's the best I could find. Once we get some behaviour that would break with values other than objects, we can always change this test to assert that we don't get errors in that scenario, for instance.