### PR TITLE
Trim objects with no unredacted values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,14 @@ module.exports = (
       const path = this.path.join('.');
       const isBuffer = Buffer.isBuffer(get(values, path));
 
+      if (trim) {
+        this.after(function(node) {
+          if (!this.isLeaf && Object.values(node).every(value => value === undefined)) {
+            return this.isRoot ? this.update(undefined, true) : this.delete();
+          }
+        });
+      }
+
       if (!isBuffer && !this.isLeaf) {
         return;
       }
@@ -51,7 +59,7 @@ module.exports = (
         if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
           blacklistedKeys.push(this.path.join('.'));
 
-          return this.update(undefined, true);
+          return this.isRoot ? this.update(undefined, true) : this.delete();
         }
       }
 

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -258,12 +258,11 @@ describe('Anonymizer', () => {
         expect(
           anonymize({
             biz: 'baz',
-            buz: { qux: 'quux' },
+            buz: { bux: { qux: 'quux' } },
             foo: 'bar'
           })
         ).toEqual({
-          __redacted__: ['biz', 'buz.qux'],
-          buz: {},
+          __redacted__: ['biz', 'buz.bux.qux'],
           foo: 'bar'
         });
       });


### PR DESCRIPTION
So that we don't get a bunch of empty objects just because all its keys go redacted.

We're updating the node to `undefined` instead of deleting it when it's the root, because otherwise `traverse` crashes (its delete method doesn't take into account the root scenario, unlike its update method).