### PR TITLE
Avoid trimming obfuscated values with different obfuscation techniques

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,17 +55,15 @@ module.exports = (
         return this.update(Buffer.from(this.node), true);
       }
 
-      if (trim) {
-        if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
+      const replacedValue = replacement(this.key, this.node, this.path);
+
+      if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
+        if (trim && replacedValue === DEFAULT_REPLACEMENT) {
           blacklistedKeys.push(this.path.join('.'));
 
           return this.isRoot ? this.update(undefined, true) : this.delete();
         }
-      }
 
-      const replacedValue = replacement(this.key, this.node, this.path);
-
-      if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
         this.update(replacedValue);
       }
     });

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -266,6 +266,35 @@ describe('Anonymizer', () => {
           foo: 'bar'
         });
       });
+
+      it('should not trim obfuscated values that have different obfuscation techniques', () => {
+        const replacement = (key, value) => {
+          if (key === 'biz') {
+            return value;
+          }
+
+          if (value === 'bux') {
+            return '--HIDDEN--';
+          }
+
+          return '--REDACTED--';
+        };
+        const anonymize = anonymizer({ whitelist: ['foo'] }, { replacement, trim: true });
+
+        expect(
+          anonymize({
+            biz: 'baz',
+            buz: 'bux',
+            foo: 'bar',
+            qux: 'quux'
+          })
+        ).toEqual({
+          __redacted__: ['qux'],
+          biz: 'baz',
+          buz: '--HIDDEN--',
+          foo: 'bar'
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This allows us to pass a custom `replacement` function and read its results even when `trim` is enabled.

This is useful for instance if we want to override some blacklists or redact only parts of the value (e.g. URLs).