### PR TITLE
Group trimmed array keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ module.exports = (
       return values;
     }
 
-    const blacklistedKeys = [];
+    const blacklistedKeys = new Set();
     const obj = JSON.parse(stringify(values));
 
     traverse(obj).forEach(function() {
@@ -59,7 +59,9 @@ module.exports = (
 
       if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
         if (trim && replacedValue === DEFAULT_REPLACEMENT) {
-          blacklistedKeys.push(this.path.join('.'));
+          const path = this.path.map(value => (isNaN(value) ? value : '[]'));
+
+          blacklistedKeys.add(path.join('.'));
 
           return this.isRoot ? this.update(undefined, true) : this.delete();
         }
@@ -68,9 +70,9 @@ module.exports = (
       }
     });
 
-    if (blacklistedKeys.length) {
+    if (blacklistedKeys.size) {
       // eslint-disable-next-line no-underscore-dangle
-      obj.__redacted__ = blacklistedKeys;
+      obj.__redacted__ = Array.from(blacklistedKeys);
     }
 
     return obj;

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -252,6 +252,20 @@ describe('Anonymizer', () => {
     });
 
     describe('trim', () => {
+      it('should group array keys', () => {
+        const anonymize = anonymizer({ whitelist: ['foo'] }, { trim: true });
+
+        expect(
+          anonymize({
+            buz: [{ biz: 'baz' }, { biz: 'biz' }, { bar: 'foo', biz: 'boz' }],
+            foo: 'bar'
+          })
+        ).toEqual({
+          __redacted__: ['buz.[].biz', 'buz.[].bar'],
+          foo: 'bar'
+        });
+      });
+
       it('should trim obfuscated fields and add their paths to a `__redacted__` list', () => {
         const anonymize = anonymizer({ whitelist: ['foo'] }, { trim: true });
 


### PR DESCRIPTION
Groups array keys in an attempt to reduce the output (which isn't very interesting).

For example, it groups this:

```js
__redacted: [
  'foo.0.bar',
  'foo.1.bar',
  'foo.2.bar',
  'foo.3.bar',
  'foo.4.bar',
  'foo.5.bar',
  'foo.6.bar',
  'foo.7.bar',
  'foo.8.bar'
]
```

into this:

```js
__redacted: [
  'foo.[].bar'
]
```