### PR TITLE
Add missing dependency on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "version": "uphold-scripts version"
   },
   "dependencies": {
+    "json-stringify-safe": "^5.0.1",
     "lodash.get": "^4.4.2",
     "traverse": "^0.6.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,7 +2507,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=


### PR DESCRIPTION
This PR adds the missing dependency `json-stringify-safe` on package.json.