### PR TITLE
Deprecate the use of `uphold-scripts` for linting

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,1 +1,117 @@
 extends: uphold
+
+rules:
+  id-match: 0
+  no-underscore-dangle: 0
+
+  # Disable prettier.
+  prettier/prettier: 0
+
+  # These can be removed once prettier is enabled.
+  array-bracket-spacing:
+    - error
+  arrow-parens:
+    - error
+    - as-needed
+  arrow-spacing:
+    - error
+  brace-style:
+    - error
+    - 1tbs
+    - allowSingleLine: true
+  comma-dangle:
+    - error
+  comma-spacing:
+    - error
+  comma-style:
+    - error
+  computed-property-spacing:
+    - error
+  dot-location:
+    - error
+    - property
+  eol-last:
+    - error
+  generator-star-spacing:
+    - error
+    - before
+  indent:
+    - error
+    - 2
+    - SwitchCase: 1
+  key-spacing:
+    - error
+  keyword-spacing:
+    - error
+  linebreak-style:
+    - error
+  new-parens:
+    - error
+  no-confusing-arrow:
+    - error
+  no-extra-parens:
+    - error
+  no-floating-decimal:
+    - error
+  no-multi-spaces:
+    - error
+  no-multiple-empty-lines:
+    - error
+    - max: 1
+  no-spaced-func:
+    - error
+  no-trailing-spaces:
+    - error
+  no-unexpected-multiline:
+    - error
+  object-curly-spacing:
+    - error
+    - always
+  one-var:
+    - error
+    - never
+  one-var-declaration-per-line:
+    - error
+    - always
+  operator-linebreak:
+    - error
+    - none
+  padded-blocks:
+    - error
+    - never
+  prefer-arrow-callback:
+    - error
+  prefer-destructuring:
+    - error
+  quote-props:
+    - error
+    - as-needed
+  quotes:
+    - error
+    - single
+    - allowTemplateLiterals: true
+  semi:
+    - error
+  semi-spacing:
+    - error
+  sort-keys-fix/sort-keys-fix:
+    - error
+    - asc
+    - natural: true
+  space-before-blocks:
+    - error
+  space-before-function-paren:
+    - error
+    - anonymous: never
+      named: never
+  space-in-parens:
+    - error
+  space-infix-ops:
+    - error
+  space-unary-ops:
+    - error
+  template-curly-spacing:
+    - error
+  wrap-iife:
+    - error
+    - inside

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "changelog": "uphold-scripts changelog $npm_package_version",
-    "lint": "uphold-scripts lint",
+    "lint": "eslint --cache . ",
     "release": "uphold-scripts release",
     "test": "TZ=UTC jest",
     "version": "uphold-scripts version"
@@ -34,7 +34,10 @@
     "traverse": "^0.6.6"
   },
   "devDependencies": {
+    "eslint": "~8.20.0",
+    "eslint-config-uphold": "^4.1.0",
     "jest": "28.1.3",
+    "prettier": "^2.8.3",
     "uphold-scripts": "0.8.0"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ module.exports.anonymizer = (
 
       if (blacklistPaths.test(path) || !whitelistPaths.test(path)) {
         if (trim && replacedValue === DEFAULT_REPLACEMENT) {
-          const path = this.path.map(value => (isNaN(value) ? value : '[]'));
+          const path = this.path.map(value => { return isNaN(value) ? value : '[]'; });
 
           blacklistedKeys.add(path.join('.'));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,7 +422,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eslint/eslintrc@^1.0.5":
+"@eslint/eslintrc@^1.0.5", "@eslint/eslintrc@^1.3.0":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
   integrity sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
@@ -1755,7 +1755,7 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz#dec1d29ab728f4fa63061774e1672ac4e363d207"
   integrity sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==
 
-eslint-config-uphold@^4.0.0:
+eslint-config-uphold@^4.0.0, eslint-config-uphold@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-uphold/-/eslint-config-uphold-4.1.0.tgz#633ae7c8ad9985f14e6dfcd9470c6a642c919c6c"
   integrity sha512-sLxhnMn/gDwiCB8atrJiAtMi0Xd/7bw3TO9uhTMADJq4mioJKYQtw97MnpNqHIjJl3Zx7vhMCtV8txg61l8Wlg==
@@ -1829,7 +1829,7 @@ eslint-scope@5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^7.1.0:
+eslint-scope@^7.1.0, eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
   integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
@@ -1858,6 +1858,47 @@ eslint-visitor-keys@^3.2.0, eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
+
+eslint@~8.20.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.20.0.tgz#048ac56aa18529967da8354a478be4ec0a2bc81b"
+  integrity sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==
+  dependencies:
+    "@eslint/eslintrc" "^1.3.0"
+    "@humanwhocodes/config-array" "^0.9.2"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.1.1"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.3.0"
+    espree "^9.3.2"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^6.0.1"
+    globals "^13.15.0"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    regexpp "^3.2.0"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
 
 eslint@~8.7.0:
   version "8.7.0"
@@ -1909,7 +1950,7 @@ espree@^6.1.2:
     acorn-jsx "^5.1.0"
     eslint-visitor-keys "^1.1.0"
 
-espree@^9.3.0, espree@^9.4.0:
+espree@^9.3.0, espree@^9.3.2, espree@^9.4.0:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
   integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
@@ -2145,7 +2186,7 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^13.19.0, globals@^13.6.0:
+globals@^13.15.0, globals@^13.19.0, globals@^13.6.0:
   version "13.20.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
   integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
@@ -3684,7 +3725,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.4.1:
+prettier@^2.4.1, prettier@^2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
   integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==


### PR DESCRIPTION
## Description
This PR swaps the current `lint` command that uses `uphold-scripts` for `eslint` using `uphold-config-eslint`.