### PR TITLE
Add support for serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Object redaction with whitelist and blacklist. Blacklist items have higher prior
 3. `options` _(Object)_: An object with optional options.
 
     `options.replacement` _(Function)_: A function that allows customizing the replacement value (default implementation is `--REDACTED--`).
-    
+
+    `options.serializers` _(List[Object])_: A list with serializers to apply. Each serializers must contain two properties: `path` (path for the value to be serialized, must be a `string`) and `serializer` (function to be called on the path's value).
+
     `options.trim` _(Boolean)_: A flag that enables trimming all redacted values, saving their keys to a `__redacted__` list (default value is `false`).
 
 ### Example
 
 ```js
-const anonymizer = require('@uphold/anonymizer');
+const { anonymizer } = require('@uphold/anonymizer');
 const whitelist = ['foo.key', 'foo.depth.*', 'bar.*', 'toAnonymize.baz', 'toAnonymizeSuperString'];
 const blacklist = ['foo.depth.innerBlacklist', 'toAnonymize.*'];
 const anonymize = anonymizer({ blacklist, whitelist });
@@ -36,6 +38,65 @@ anonymize(data);
 //   bar: { foo: 1, bar: 2 },
 //   toAnonymize: { baz: '--REDACTED--', bar: '--REDACTED--' },
 //   toAnonymizeSuperString: '--REDACTED--'
+// }
+```
+
+#### Example using serializers
+
+```js
+const { anonymizer } = require('@uphold/anonymizer');
+const whitelist = ['foo.key', 'foo.depth.*', 'bar.*', 'toAnonymize.baz'];
+const blacklist = ['foo.depth.innerBlacklist'];
+const serializers = [
+  { path: 'foo.key', serializer: () => 'biz' },
+  { path: 'toAnonymize', serializer: () => ({ baz: 'baz' }) }
+]
+const anonymize = anonymizer({ blacklist, whitelist }, { serializers });
+
+const data = {
+  foo: { key: 'public', another: 'bar', depth: { bar: 10, innerBlacklist: 11 } },
+  bar: { foo: 1, bar: 2 },
+  toAnonymize: {}
+};
+
+anonymize(data);
+
+// {
+//   foo: {
+//     key: 'biz',
+//     another: '--REDACTED--',
+//     depth: { bar: 10, innerBlacklist: '--REDACTED--' }
+//   },
+//   bar: { foo: 1, bar: 2 },
+//   toAnonymize: { baz: 'baz' }
+// }
+```
+
+### Default serializers
+
+The introduction of serializers also added the possibility of using serializer functions exported by our module. The list of default serializers is presented below:
+- error
+
+#### Example
+
+```js
+const { anonymizer, defaultSerializers } = require('@uphold/anonymizer');
+const serializers = [
+  { path: 'foo', serializer: defaultSerializers.error }
+];
+
+const anonymize = anonymizer({}, { serializers });
+
+const data = { foo: new Error('Foobar') };
+
+anonymize(data);
+
+// {
+//   foo: {
+//     name: '--REDACTED--',
+//     message: '--REDACTED--',
+//     stack: '--REDACTED--'
+//   }
 // }
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
   },
   "dependencies": {
     "json-stringify-safe": "^5.0.1",
+    "lodash.clonedeep": "^4.5.0",
+    "lodash.clonedeepwith": "^4.5.0",
     "lodash.get": "^4.4.2",
+    "lodash.set": "^4.3.2",
+    "serialize-error": "8.0.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,11 @@
  * Module dependencies.
  */
 
+const { serializeError } = require('serialize-error');
+const cloneDeep = require('lodash.clonedeep');
+const cloneDeepWith = require('lodash.clonedeepwith');
 const get = require('lodash.get');
+const set = require('lodash.set');
 const stringify = require('json-stringify-safe');
 const traverse = require('traverse');
 
@@ -15,17 +19,110 @@ const traverse = require('traverse');
 const DEFAULT_REPLACEMENT = '--REDACTED--';
 
 /**
- * Module exports.
+ * Gets a list with all properties of an object.
  */
 
-module.exports = (
+function getAllPropertyNames(obj, maxChainLength = 10) {
+  const set = new Set();
+  let i = 0;
+
+  while (obj.constructor !== Object && i < maxChainLength) {
+    Object.getOwnPropertyNames(obj).forEach(name => set.add(name));
+    obj = Object.getPrototypeOf(obj);
+    i++;
+  }
+
+  return [...set];
+}
+
+/**
+ * Custom error clone.
+ */
+
+function customErrorClone(error) {
+  const clone = {};
+
+  getAllPropertyNames(error).forEach(key => {
+    const isConstructor = key === 'constructor';
+    const isFunction = typeof error[key] === 'function';
+
+    if (!isConstructor && !isFunction) {
+      clone[key] = cloneDeep(error[key]);
+    }
+  });
+
+  return clone;
+}
+
+/**
+ * Validate serializers.
+ */
+
+function validateSerializers(serializers) {
+  serializers.forEach(({ path, serializer }) => {
+    if (typeof serializer !== 'function') {
+      throw new TypeError(`Invalid serializer for \`${path}\` path: must be a function`);
+    }
+  });
+}
+
+/**
+ * `parseAndSerialize` builds a copy of the original object, computes the serializer's results and mutates the
+ * copy with the serialized values. To perform the copy, we are using JSON.parse(stringify(values)), which does
+ * not construct an exact replication of the initial input, but it can't be swapped for another solution due to
+ * its performance and because it can also handle classes correctly. While most of the existing deep clones, when
+ * cloning Classes receive a `Class` as input and return a `Class` as output, `stringify` does things differently.
+ * When it receives a `Class`, it calls the method `toJSON` and returns its output or if the `Class` doesn't have
+ * `toJSON` it returns an empty object. This is very powerful since `traverse` can't iterate over `Classes`.
+ * During `parseAndSerialize` execution, we perform additional copies to avoid having a serializer updating the
+ * original object by reference. These copies are only done in the values passed to serializers to avoid two full
+ * copies of the original values. For this, we used `cloneDeepWith` with a custom clone only for errors. When an
+ * error is found, we compute a list with all properties (properties from the class itself and from extended cla-
+ * sses). Then we use these properties to get the original values and copying them into a new object.
+ */
+
+function parseAndSerialize(values, serializers) {
+  const target = JSON.parse(stringify(values));
+
+  for (const { path, serializer } of serializers) {
+    const value = get(values, path);
+
+    if (value === undefined) {
+      continue;
+    }
+
+    try {
+      const copy = cloneDeepWith(value, node => {
+        if (node instanceof Error) {
+          return customErrorClone(node);
+        }
+
+        return undefined;
+      });
+
+      set(target, path, serializer(copy));
+    } catch (error) {
+      set(target, path, 'Anonymize ERROR: Error while applying serializer');
+    }
+  }
+
+  return target;
+}
+
+/**
+ * Module exports `anonymizer` function.
+ */
+
+module.exports.anonymizer = (
   { blacklist = [], whitelist = [] } = {},
-  { replacement = () => DEFAULT_REPLACEMENT, trim = false } = {}
+  { replacement = () => DEFAULT_REPLACEMENT, serializers = [], trim = false } = {}
 ) => {
   const whitelistTerms = whitelist.join('|');
   const whitelistPaths = new RegExp(`^(${whitelistTerms.replace(/\./g, '\\.').replace(/\*/g, '.*')})$`, 'i');
   const blacklistTerms = blacklist.join('|');
   const blacklistPaths = new RegExp(`^(${blacklistTerms.replace(/\./g, '\\.').replace(/\*/g, '.*')})$`, 'i');
+
+  validateSerializers(serializers);
 
   return values => {
     if (!(values instanceof Object)) {
@@ -33,7 +130,7 @@ module.exports = (
     }
 
     const blacklistedKeys = new Set();
-    const obj = JSON.parse(stringify(values));
+    const obj = parseAndSerialize(values, serializers);
 
     traverse(obj).forEach(function() {
       const path = this.path.join('.');
@@ -51,7 +148,7 @@ module.exports = (
         return;
       }
 
-      if (isBuffer && (!blacklistPaths.test(path) && whitelistPaths.test(path))) {
+      if (isBuffer && !blacklistPaths.test(path) && whitelistPaths.test(path)) {
         return this.update(Buffer.from(this.node), true);
       }
 
@@ -77,4 +174,24 @@ module.exports = (
 
     return obj;
   };
+};
+
+/**
+ * Default serializer for Datadog.
+ */
+
+function datadogSerializer(error) {
+  return {
+    ...error,
+    kind: error.name || 'Error'
+  };
+}
+
+/**
+ * Module exports `defaultSerializers`.
+ */
+
+module.exports.defaultSerializers = {
+  datadogSerializer,
+  error: serializeError
 };

--- a/test/src/benchmark/samples.js
+++ b/test/src/benchmark/samples.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * `generateObjectSample` generates a sample object with a tree structure.
+ */
+
+module.exports.generateObjectSample = ({ depth = 6, branches = 2, leafValue = () => 'foobar', leafs = 32 }) => {
+  const sample = {};
+
+  if (depth === 0) {
+    for (let leaf = 0; leaf < leafs; leaf++) {
+      sample[`leaf-${leaf}`] = leafValue();
+    }
+
+    return sample;
+  }
+
+  for (let branch = 0; branch < branches; branch++) {
+    sample[`branch-${branch}`] = this.generateObjectSample({ branches, depth: depth - 1, leafs });
+  }
+
+  return sample;
+};
+
+/**
+ * `generateObjectSamplePaths` generates a list with all paths contained in a sample generated using `generateObjectSample`.
+ */
+
+module.exports.generateObjectSamplePaths = ({ depth = 6, branches = 2, leafs = 32, path = '' }) => {
+  let paths = [];
+
+  if (depth === 0) {
+    for (let leaf = 0; leaf < leafs; leaf++) {
+      paths.push(`${path}.leaf-${leaf}`);
+    }
+
+    return paths;
+  }
+
+  for (let branch = 0; branch < branches; branch++) {
+    const childPathString = path === '' ? `branch-${branch}` : `${path}.branch-${branch}`;
+    const childPaths = this.generateObjectSamplePaths({ branches, depth: depth - 1, leafs, path: childPathString });
+
+    paths = paths.concat(childPaths);
+  }
+
+  return paths;
+};

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -4,7 +4,12 @@
  * Module dependencies.
  */
 
-const anonymizer = require('src');
+const {
+  anonymizer,
+  defaultSerializers: { datadogSerializer }
+} = require('src');
+const { generateObjectSample, generateObjectSamplePaths } = require('./benchmark/samples');
+const { serializeError } = require('serialize-error');
 
 /**
  * Test `Anonymizer`.
@@ -251,6 +256,310 @@ describe('Anonymizer', () => {
       });
     });
 
+    describe('serializers', () => {
+      it('should throw an error when serializer is not a function', () => {
+        const serializers = [{ path: 'foo', serializer: 123 }];
+        const whitelist = ['*'];
+
+        try {
+          anonymizer({ whitelist }, { serializers });
+
+          fail();
+        } catch (error) {
+          expect(error).toBeInstanceOf(TypeError);
+          expect(error.message).toEqual('Invalid serializer for `foo` path: must be a function');
+        }
+      });
+
+      it('should apply serializers to existing paths', () => {
+        const foobar = jest.fn(() => 'bii');
+        const foobiz = jest.fn(() => 'bzz');
+        const foobzz = jest.fn(() => ({ bar: 'biz' }));
+        const whitelist = ['*'];
+        const serializers = [
+          { path: 'bar', serializer: foobiz },
+          { path: 'foo', serializer: foobar },
+          { path: 'foobar', serializer: foobzz }
+        ];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize({ foo: 'bar' });
+
+        expect(foobar).toHaveBeenCalledTimes(1);
+        expect(foobar).toHaveBeenCalledWith('bar');
+        expect(foobiz).toHaveBeenCalledTimes(0);
+        expect(foobzz).toHaveBeenCalledTimes(0);
+        expect(result.foo).toEqual('bii');
+      });
+
+      it('should apply serializers to nested paths', () => {
+        const error = new Error('foobar');
+        const foobar = jest.fn(() => 'bii');
+        const foobiz = jest.fn(() => 'bzz');
+        const fooerror = jest.fn(serializeError);
+        const whitelist = ['*'];
+        const serializers = [
+          { path: 'bar.foo', serializer: foobiz },
+          { path: 'bar.error', serializer: fooerror },
+          { path: 'foo.bar.biz', serializer: foobar }
+        ];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize({
+          bar: { error, foo: 'bar' },
+          foo: {
+            bar: { biz: 'foo' }
+          }
+        });
+
+        expect(foobar).toHaveBeenCalledTimes(1);
+        expect(foobar).toHaveBeenCalledWith('foo');
+        expect(foobiz).toHaveBeenCalledTimes(1);
+        expect(foobiz).toHaveBeenCalledWith('bar');
+        expect(result.bar.foo).toEqual('bzz');
+        expect(result.bar.error).toHaveProperty('name', 'Error');
+        expect(result.bar.error).toHaveProperty('message', 'foobar');
+        expect(result.foo).toEqual({ bar: { biz: 'bii' } });
+      });
+
+      it('should not change original values by reference', () => {
+        const data = { foo: 'bar', foz: { baz: 'baz', biz: 'biz' } };
+        const foobar = jest.fn(() => 'bii');
+        const fozbar = jest.fn(value => {
+          value.baz = 'biz';
+
+          return 'biz';
+        });
+        const whitelist = ['*'];
+        const serializers = [{ path: 'foo', serializer: foobar }, { path: 'foz', serializer: fozbar }];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize(data);
+
+        expect(data).toEqual({ foo: 'bar', foz: { baz: 'baz', biz: 'biz' } });
+        expect(foobar).toHaveBeenCalledTimes(1);
+        expect(foobar).toHaveBeenCalledWith('bar');
+        expect(result.foo).toEqual('bii');
+        expect(result.foz).toEqual('biz');
+      });
+
+      it('should serialize errors that extend `Error`', () => {
+        class ValidationError extends Error {
+          constructor(message) {
+            super(message);
+            this.name = 'ValidationError';
+            this.foo = 'bar';
+          }
+        }
+
+        const error = new ValidationError('foobar');
+        const serializer = jest.fn(datadogSerializer);
+        const serializers = [{ path: 'error', serializer }];
+        const whitelist = ['error.foo', 'error.kind', 'error.message', 'error.name', 'error.stack'];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize({ error });
+
+        expect(serializer).toHaveBeenCalledTimes(1);
+        expect(result.error).toEqual({
+          foo: 'bar',
+          kind: 'ValidationError',
+          message: 'foobar',
+          name: 'ValidationError',
+          stack: error.stack
+        });
+      });
+
+      it('should serialize errors that extend multiple classes', () => {
+        class ErrorOne extends Error {
+          constructor(message) {
+            super(message);
+            this.name = 'ErrorOne';
+            this.foo = 'bar';
+          }
+        }
+
+        class ErrorTwo extends ErrorOne {
+          constructor(message) {
+            super(message);
+            this.name = 'ErrorTwo';
+            this.foo = 'baz';
+          }
+        }
+
+        const error = new ErrorTwo('foobar');
+        const serializer = jest.fn(datadogSerializer);
+        const serializers = [{ path: 'error', serializer }];
+        const whitelist = ['error.foo', 'error.kind', 'error.message', 'error.name', 'error.stack'];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize({ error });
+
+        expect(serializer).toHaveBeenCalledTimes(1);
+        expect(result.error).toEqual({
+          foo: 'baz',
+          kind: 'ErrorTwo',
+          message: 'foobar',
+          name: 'ErrorTwo',
+          stack: error.stack
+        });
+      });
+
+      it('should not change original values of serialized errors', () => {
+        class ValidationError extends Error {
+          constructor(message) {
+            super(message);
+            this.name = 'ValidationError';
+            this.foo = { for: 'baz' };
+          }
+        }
+
+        const error = new ValidationError('foobar');
+        const serializer = jest.fn(value => {
+          const serialized = datadogSerializer(value);
+
+          value.foo.for = 'bar';
+
+          return serialized;
+        });
+        const serializers = [{ path: 'error', serializer }];
+        const whitelist = ['*'];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize({ error });
+
+        expect(serializer).toHaveBeenCalledTimes(1);
+        expect(result.error).toEqual({
+          foo: { for: 'bar' },
+          kind: 'ValidationError',
+          message: 'foobar',
+          name: 'ValidationError',
+          stack: error.stack
+        });
+        expect(error.foo.for).toEqual('baz');
+      });
+
+      it('should not change deep original values of serialized errors', () => {
+        class ValidationError extends Error {
+          constructor(message) {
+            super(message);
+            this.name = 'ValidationError';
+            this.foo = { for: { bar: { foo: 'baz' } } };
+          }
+        }
+
+        const error = new ValidationError('foobar');
+        const serializer = jest.fn(value => {
+          const serialized = datadogSerializer(value);
+
+          value.foo.for.bar.foo = 'bar';
+
+          return serialized;
+        });
+        const serializers = [{ path: 'error', serializer }];
+        const whitelist = ['*'];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize({ error });
+
+        expect(serializer).toHaveBeenCalledTimes(1);
+        expect(result.error).toEqual({
+          foo: { for: { bar: { foo: 'bar' } } },
+          kind: 'ValidationError',
+          message: 'foobar',
+          name: 'ValidationError',
+          stack: error.stack
+        });
+        expect(error.foo.for.bar.foo).toEqual('baz');
+      });
+
+      it('should not propagate an error thrown by a serializer', () => {
+        const data = { foo: 'bar', foz: 'biz' };
+        const serializer = jest.fn(() => {
+          throw new Error('foobar');
+        });
+        const serializers = [{ path: 'foo', serializer }, { path: 'foz', serializer }];
+        const whitelist = ['*'];
+        const anonymize = anonymizer({ whitelist }, { serializers });
+
+        const result = anonymize(data);
+
+        expect(result).toEqual({
+          foo: 'Anonymize ERROR: Error while applying serializer',
+          foz: 'Anonymize ERROR: Error while applying serializer'
+        });
+        expect(serializer).toHaveBeenCalledTimes(2);
+      });
+
+      describe('defaultSerializers', () => {
+        it('should serialize errors when `serializeError()` is applied', () => {
+          const error = new Error('foobar');
+          const serializer = jest.fn(serializeError);
+          const serializers = [{ path: 'e', serializer }, { path: 'err', serializer }, { path: 'error', serializer }];
+          const whitelist = ['*'];
+          const anonymize = anonymizer({ whitelist }, { serializers });
+
+          const result = anonymize({
+            e: error,
+            err: {
+              statusCode: 400
+            },
+            error,
+            error2: error,
+            foo: 'bar'
+          });
+
+          expect(serializer).toHaveBeenCalledTimes(3);
+          expect(result.e).toEqual({
+            message: 'foobar',
+            name: 'Error',
+            stack: error.stack
+          });
+          expect(result.err).toEqual({
+            statusCode: 400
+          });
+          expect(result.error).toEqual({
+            message: 'foobar',
+            name: 'Error',
+            stack: error.stack
+          });
+          expect(result.error2).toEqual({});
+          expect(result.foo).toEqual('bar');
+        });
+
+        it('should serialize errors when `datadogSerializer()` is applied', () => {
+          const error = new Error('foobar');
+          const serializer = jest.fn(datadogSerializer);
+          const serializers = [{ path: 'err', serializer }, { path: 'error', serializer }];
+          const whitelist = ['error.foo', 'error.kind', 'error.message', 'error.name', 'error.stack'];
+          const anonymize = anonymizer({ whitelist }, { serializers });
+
+          const result = anonymize({
+            e: error,
+            err: {
+              statusCode: 400
+            },
+            error,
+            error2: error,
+            foo: 'bar'
+          });
+
+          expect(serializer).toHaveBeenCalledTimes(2);
+          expect(result.err).toEqual({
+            kind: '--REDACTED--',
+            statusCode: '--REDACTED--'
+          });
+          expect(result.error).toEqual({
+            kind: 'Error',
+            message: 'foobar',
+            name: 'Error',
+            stack: error.stack
+          });
+          expect(result.foo).toEqual('--REDACTED--');
+        });
+      });
+    });
+
     describe('trim', () => {
       it('should group array keys', () => {
         const anonymize = anonymizer({ whitelist: ['foo'] }, { trim: true });
@@ -308,6 +617,56 @@ describe('Anonymizer', () => {
           buz: '--HIDDEN--',
           foo: 'bar'
         });
+      });
+    });
+
+    describe.skip('benchmark', () => {
+      it('should run a sample with `32768` properties in less than `150` ms', () => {
+        const depth = 10;
+        const data = generateObjectSample({ depth });
+        const anonymize = anonymizer({ blacklist: ['*'] });
+        const startTime = process.hrtime();
+
+        anonymize(data);
+
+        const endTime = process.hrtime(startTime);
+        const msElapsed = endTime[1] / 1000000;
+
+        expect(msElapsed).toBeLessThan(150);
+      });
+
+      it('should call serializers in all `32768` properties in less than `250` ms', () => {
+        const depth = 10;
+        const data = generateObjectSample({ depth });
+        const serializer = jest.fn(() => 'bii');
+        const serializers = generateObjectSamplePaths({ depth }).map(path => ({ path, serializer }));
+        const anonymize = anonymizer({ blacklist: ['*'] }, { serializers });
+        const startTime = process.hrtime();
+
+        anonymize(data);
+
+        const endTime = process.hrtime(startTime);
+        const msElapsed = endTime[1] / 1000000;
+
+        expect(msElapsed).toBeLessThan(250);
+        expect(serializer).toHaveBeenCalledTimes(32768);
+      });
+
+      it('should call `serializeError` in all `32768` properties in less than `175` ms', () => {
+        const depth = 10;
+        const data = generateObjectSample({ depth, leafValue: () => new Error('foobar') });
+        const serializer = jest.fn(serializeError);
+        const serializers = generateObjectSamplePaths({ depth }).map(path => ({ path, serializer }));
+        const anonymize = anonymizer({ blacklist: ['*'] }, { serializers });
+        const startTime = process.hrtime();
+
+        anonymize(data);
+
+        const endTime = process.hrtime(startTime);
+        const msElapsed = endTime[1] / 1000000;
+
+        expect(msElapsed).toBeLessThan(175);
+        expect(serializer).toHaveBeenCalledTimes(32768);
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,6 +2405,16 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
+lodash.clonedeepwith@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz#6ee30573a03a1a60d670a62ef33c10cf1afdbdd4"
+  integrity sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -2414,6 +2424,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
 lodash@^4.17.13:
   version "4.17.19"
@@ -2857,6 +2872,13 @@ semver@^7.3.5:
   integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
   dependencies:
     lru-cache "^6.0.0"
+
+serialize-error@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.0.0.tgz#2b3ea8a25bbd4375d54a9080ccc3d6d6262e34c0"
+  integrity sha512-NEi2T2V5YsmT26QCeOKh62pS+7xfG1vuYuOZQTIQ2yzAB6XJk/klyD6qOrhz4wLmrGNP1RkdIM0hFHeNX3ai+w==
+  dependencies:
+    type-fest "^0.20.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Description
This PR adds the same feature as [anonymizer#21](https://github.com/uphold/anonymizer/pull/21), however it implements a custom clone for errors. After many different approaches (`structureClone`, `deepClone`, `JSON.parse`), we couldn't find a solution that kept all the error data during the copy process. The solution with this PR, uses `lodash.cloneDeepWith` and tests if the node being copied is an error. Then we compute a list of all properties inside that node (properties from the class itself and properties inherited from extending other classes). We then build a new object containing all this properties and their respective values.

Apart from this, everything was kept the same.  The user needs to specify a list of objects containing: a property _path_ specifying a path to a value inside the input object; a property _serializer_ containing a function that will be called with the value obtained using the _path_. The user may define its custom serializers or choose from a list exported by our module. This will introduce a **breaking change** since the module now exports the `anonymizer` function as well as an object with serializers provided by the application. It should be used as follows:

```js
const { anonymizer, defaultSerializers } = require('@uphold/anonymizer');

const serializers = [
  { path: 'bar', serializer: () => 'biz' },
  { path: 'foo', serializer: defaultSerializers.error },
  { path: 'foobar.biz', serializer: () => 'baz' }
]

const anonymize = anonymizer({ whitelist }, { serializers });

const result = anonymize({ foo: 'bar' });
```

## Related issues
https://uphold.atlassian.net/browse/BKO-3707