### PR TITLE
Fix publishing to npm as part of the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,7 @@ jobs:
     - name: Generate release
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-      run: yarn run release --increment "${{ github.event.inputs.VERSION_BUMP }}" -V
+        NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}
+      run: |
+        echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+        npm run release -- --increment "${{ github.event.inputs.VERSION_BUMP }}" -V


### PR DESCRIPTION
Missing `NPM_TOKEN` and setup of npmrc