### PR TITLE
Pin traverse@0.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.21",
     "serialize-error": "^8.0.0",
-    "traverse": "^0.6.9"
+    "traverse": "0.6.9"
   },
   "devDependencies": {
     "@uphold/github-changelog-generator": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4980,7 +4980,7 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-traverse@^0.6.9:
+traverse@0.6.9:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.9.tgz#76cfdbacf06382d460b76f8b735a44a6209d8b81"
   integrity sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==


### PR DESCRIPTION
Version 0.6.10 brought about a bug that makes traverse not work correctly on arrays when the option trim is true. This PR just pins the version of traverse to 0.6.9 since it is currently works for our purposes (the `remove()` has a bug, but we don't use it in this package).

Note: we can kind of fix the bug here, since the `delete()` call is where the bug starts, if we skip it and just do the delete directly, the code works with version 0.6.10 of traverse.