### PR TITLE
Standardize serializer exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Built-in serializer functions you may use in the `serializers` option.
 
 Serializes an `Error` object.
 
-#### datadogSerializer
+#### datadogError
 
 Serializes an `Error` object for the purpose of sending it to Datadog, adding a `kind` property based on the error class name.
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
  */
 
 const { cloneDeep, cloneDeepWith, escapeRegExp, get, set } = require('lodash');
-const { serializeError } = require('serialize-error');
+const { serializeError: errorSerializer } = require('serialize-error');
 const stringify = require('json-stringify-safe');
 const traverse = require('traverse');
 
@@ -215,7 +215,7 @@ module.exports.anonymizer = (
  * Default serializer for Datadog.
  */
 
-function datadogSerializer(error) {
+function datadogErrorSerializer(error) {
   return {
     ...error,
     kind: error.name || 'Error'
@@ -223,10 +223,10 @@ function datadogSerializer(error) {
 }
 
 /**
- * Module exports `defaultSerializers`.
+ * Module exports `serializers`.
  */
 
-module.exports.defaultSerializers = {
-  datadogSerializer,
-  error: serializeError
+module.exports.serializers = {
+  datadogError: datadogErrorSerializer,
+  error: errorSerializer
 };


### PR DESCRIPTION
The current serializer exports is strange:

- Exports it as `defaultSerializers`, but none of those are applied by default, unlike bunyan or pino.
- Has `error` and `datadogSerializer` which is inconsistent.. one has `Serializer` prefix and another doesn't.

This PR addresses these inconsistencies. Contains breaking changes.