### PR TITLE
Fix redaction when double wildcards are used in certain conditions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,6 @@ const createPathTester = patterns => {
     // Escape regex special characters.
     escapeRegExp(pattern)
       // Handle `**` feature.
-      .replaceAll('\\.\\*\\*\\.', '\\..*')
       .replaceAll('\\*\\*\\.', '(.*\\.)?')
       .replaceAll('\\*\\*', '.*')
       // Handle `*` feature.

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -233,6 +233,16 @@ describe('Anonymizer', () => {
           parent3: ['--REDACTED--', { foo: '--REDACTED--' }]
         });
 
+        expect(anonymizer({ whitelist: ['parent1.**.oo'] })(data)).toEqual({
+          foo: '--REDACTED--',
+          parent1: {
+            child: { bar: '--REDACTED--', foo: '--REDACTED--' },
+            foo: '--REDACTED--'
+          },
+          parent2: { bar: '--REDACTED--', foo: '--REDACTED--' },
+          parent3: ['--REDACTED--', { foo: '--REDACTED--' }]
+        });
+
         expect(anonymizer({ whitelist: ['**.foo'] })(data)).toEqual({
           foo: 'bar',
           parent1: {


### PR DESCRIPTION
Given the following data:

```json
{
  "evaluation": {
    "rules": [
      {
        "conditions": {
          "name-matching-score": {
            "name": "foo",
            "details": {
              "userFullName": "raj"
            }
          }
        }
      }
    ]
  }
}
```

And the following whitelist patterns:

```
['evaluation.rules.**.name']
```

The redaction is unredacting `userFullName` but it shouldn't.