### PR TITLE
Update datadog serializer to properly handle non-object errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-const { cloneDeep, cloneDeepWith, escapeRegExp, get, set } = require('lodash');
+const { cloneDeep, cloneDeepWith, escapeRegExp, get, isPlainObject, set } = require('lodash');
 const { serializeError: errorSerializer } = require('serialize-error');
 const stringify = require('json-stringify-safe');
 const traverse = require('traverse');
@@ -214,6 +214,13 @@ module.exports.anonymizer = (
  */
 
 function datadogErrorSerializer(error) {
+  if (!isPlainObject(error)) {
+    return {
+      details: error,
+      kind: 'Error'
+    };
+  }
+
   return {
     ...error,
     kind: error.name || 'Error'

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -832,9 +832,21 @@ describe('Anonymizer', () => {
           const serializer = jest.fn(builtinSerializers.datadogError);
           const serializers = [
             { path: 'err', serializer },
+            { path: 'errArr', serializer },
+            { path: 'errStr', serializer },
             { path: 'error', serializer }
           ];
-          const whitelist = ['error.foo', 'error.kind', 'error.message', 'error.name', 'error.stack'];
+          const whitelist = [
+            'errArr.details.*',
+            'errArr.kind',
+            'errStr.details',
+            'errStr.kind',
+            'error.foo',
+            'error.kind',
+            'error.message',
+            'error.name',
+            'error.stack'
+          ];
           const anonymize = anonymizer({ whitelist }, { serializers });
 
           const result = anonymize({
@@ -842,15 +854,25 @@ describe('Anonymizer', () => {
             err: {
               statusCode: 400
             },
+            errArr: ['foo', 'bar'],
+            errStr: 'foobar',
             error,
             error2: error,
             foo: 'bar'
           });
 
-          expect(serializer).toHaveBeenCalledTimes(2);
+          expect(serializer).toHaveBeenCalledTimes(4);
           expect(result.err).toEqual({
             kind: '--REDACTED--',
             statusCode: '--REDACTED--'
+          });
+          expect(result.errArr).toEqual({
+            details: ['foo', 'bar'],
+            kind: 'Error'
+          });
+          expect(result.errStr).toEqual({
+            details: 'foobar',
+            kind: 'Error'
           });
           expect(result.error).toEqual({
             kind: 'Error',


### PR DESCRIPTION
# Description
This PR updates the datadog serializer to handle errors that are not objects. This aims to fix a bug where an error represented as a string would be destructured into an object containing all the elements of the string. Example: `foobar` would produce the following output:

```json
{
  "0": "f",
  "1": "o",
  "2": "o",
  "3": "b",
  "4": "a",
  "5": "r"
}
``` 

With this fix the following error will be represented as follows:

```json
{
  "details": "foobar",
  "kind": "Error"
}
``` 